### PR TITLE
Force jquery.cookie to be included by starter theme

### DIFF
--- a/sites/all/themes/mukurtu_starter/mukurtu_starter.info
+++ b/sites/all/themes/mukurtu_starter/mukurtu_starter.info
@@ -40,6 +40,7 @@ stylesheets[all][] = font-awesome/css/font-awesome.min.css
 ; ;; Scripts
 ; ;;;;;;;;;;;;;;;;;;;;;
 ;
+scripts[] = ../../../../misc/jquery.cookie.js
 scripts[] = js/scripts.js
 scripts[] = js/masonry.pkgd.min.js
 scripts[] = 'bootstrap/js/affix.js'


### PR DESCRIPTION
Issue: #4 

Changes:

* Makes the Mukurtu Starter Theme dependent on jQuery.cookie as provided by Drupal core.
* Ensures that the script will be available whether authenticated or not.